### PR TITLE
ニコ動サイバー攻撃対応

### DIFF
--- a/nicorankLib/Analyze/RankingAnalyze.cs
+++ b/nicorankLib/Analyze/RankingAnalyze.cs
@@ -62,7 +62,7 @@ namespace nicorankLib.Analyze
                 //基本となるランキングデータを取得する
                 if (!this.Input.AnalyzeRank(out rankingList))
                 {
-                    return false;
+
                 }
 
                 foreach (var Option in BaseOptionList)

--- a/nicorankLib/Factory/ModeFactoryWeekly.cs
+++ b/nicorankLib/Factory/ModeFactoryWeekly.cs
@@ -1,11 +1,13 @@
 ﻿using nicorankLib.Analyze;
 using nicorankLib.Analyze.Input;
 using nicorankLib.Analyze.Json;
+using nicorankLib.Analyze.Official;
 using nicorankLib.Analyze.Option;
 using nicorankLib.Analyze.Option.Basic;
 using nicorankLib.api;
 using nicorankLib.Common;
 using nicorankLib.output;
+using nicorankLib.Util;
 using System;
 using System.Collections.Generic;
 
@@ -28,24 +30,51 @@ namespace nicorankLib.Factory
         }
         public override bool CreateAnalyzer()
         {
-
-            // ランキングのベースは週間JSON
-            InputBase inputBase = new JsonReaderWeekly(this.TargetDay);
+            var isMaintananceDay = false;
+            
+            using (var rankingOfficial = new RankingHistory())
+            {
+                rankingOfficial.Open();
+                isMaintananceDay = rankingOfficial.CheckMaintananceDay(this.TargetDay);
+            }
 
             //集計日を計算する
             this.BaseDay = TargetDay.AddDays(-7); //7日前
 
+            InputBase inputBase;
+            List<BasicOptionBase> options;
+
+            if (isMaintananceDay)
+            {
+                //メンテナンス日なので集計できない、中間集計で代替
+                StatusLog.WriteLine($"{this.TargetDay.ToShortDateString()}はメンテナンス日です。代替として中間集計ロジックで計算します\n");
+
+                // ランキングのベースは週間JSON
+                inputBase = new TyukanAnalyze();
+                inputBase.setAnalyzeDay(this.TargetDay);
+
+                options = new List<BasicOptionBase>()
+                {
+                    new LastRankReader(AnalyzeMode, BaseDay)          //先週の順位
+                };
+            }
+            else
+            {
+                //メンテナンス日ではない場合は、週刊JSON 
+                inputBase = new JsonReaderWeekly(this.TargetDay);
+                
+                options = new List<BasicOptionBase>()
+                {
+                    new HiddenMovieDelete()
+                    ,new SabunReader(BaseDay)                          //差分計算
+                    ,new LastRankReader(AnalyzeMode, BaseDay)          //先週の順位
+                };
+            }
+
+
             //長期判定
             this.TyokiHantei = new TyokiHantei();
             TyokiHantei.Set(OUTPUTDIR, this.TargetDay);
-
-            //集計に必要なオプションを作成する
-            var options = new List<BasicOptionBase>()
-            {
-                new HiddenMovieDelete()
-                ,new SabunReader(BaseDay)                          //差分計算
-                ,new LastRankReader(AnalyzeMode, BaseDay)          //先週の順位
-            };
 
             Config config = Config.GetInstance();
             //集計後に実行する（ランキング順位などを参照する）オプションを作成する

--- a/nicorankLib/Util/ErrLog.cs
+++ b/nicorankLib/Util/ErrLog.cs
@@ -12,10 +12,10 @@ namespace nicorankLib.Util
     /// </summary>
     public class ErrLog
     {
-        protected static ErrLog m_Instance = new ErrLog();
+        protected static ErrLog m_Instance;
         public bool IsWrite { get; protected set; }
         protected TextUtil textUtil = new TextUtil();
-        object lockobject = new object();
+        private static readonly object lockObject = new object();
 
         /// <summary>
         /// コンストラクタ
@@ -39,7 +39,15 @@ namespace nicorankLib.Util
         /// <returns></returns>
         public static ErrLog GetInstance()
         {
-            return m_Instance;
+            lock (lockObject)
+            {
+                if (m_Instance == null)
+                {
+                    //インスタンス生成
+                    m_Instance = new ErrLog();
+                }
+                return m_Instance;
+            }
         }
 
         /// <summary>

--- a/nicorankLib/Util/InternetUtil.cs
+++ b/nicorankLib/Util/InternetUtil.cs
@@ -48,13 +48,19 @@ namespace nicorankLib.Util
                     }
                     catch (WebException ex)
                     {
+                        if (ex.Status == WebExceptionStatus.ProtocolError && ex.Response.ContentType == "application/xml")
+                        {
+                            //真面目にやるのであれば中身をちゃんと解析するべきだが、AccessDeniedと見直して、再試行を抜ける
+                            break;
+                        }
+
                         switch (ex.Status)
                         {
-                            case WebExceptionStatus.ProtocolError:
+                            case WebExceptionStatus.ProtocolError:          
                             case WebExceptionStatus.Timeout:
 
                                 Thread.Sleep(1000);
-                                continue;
+                                continue; 
                         }
                     }
                     break;

--- a/nicorankLib/Util/Text/TextUtil.cs
+++ b/nicorankLib/Util/Text/TextUtil.cs
@@ -326,38 +326,41 @@ namespace nicorankLib.Util.Text
         /// <returns></returns>
         public bool WriteOpen(string filepath, bool isUnicode, bool isOverwrite = true)
         {
-            this.WriteClose();
-
-            try
+            lock (rockObject)
             {
-                var writeEncoding = isUnicode ? Encoding.UTF8 : Encoding.GetEncoding("shift_jis");
+                this.WriteClose();
 
-                if (!isOverwrite && File.Exists(filepath))
+                try
                 {
-                    //追記モードの時、最後の文字が改行で無い場合は改行を追加する
-                    using (var fs = new FileStream(filepath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
-                    {
-                        if (fs.Length > 0)
-                        {
-                            //最後の文字にSeek
-                            fs.Seek(-1, SeekOrigin.End);
-                            char lastChar = (char)fs.ReadByte();
-                            if (lastChar != '\n' && lastChar != '\r')
-                            {
-                                var byteData = writeEncoding.GetBytes($"\r\n");
-                                fs.Write(byteData, 0, byteData.Length);
-                            }
-                        }
-                        fs.Close();
-                    }
-                }
+                    var writeEncoding = isUnicode ? Encoding.UTF8 : Encoding.GetEncoding("shift_jis");
 
-                this.streamWriter = new StreamWriter(filepath, !isOverwrite, writeEncoding);
-            }
-            catch (Exception)
-            {
-                StatusLog.Write($"{filepath} を書き込み用に開けませんでした。\n");
-                return false;
+                    if (!isOverwrite && File.Exists(filepath))
+                    {
+                        //追記モードの時、最後の文字が改行で無い場合は改行を追加する
+                        using (var fs = new FileStream(filepath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+                        {
+                            if (fs.Length > 0)
+                            {
+                                //最後の文字にSeek
+                                fs.Seek(-1, SeekOrigin.End);
+                                char lastChar = (char)fs.ReadByte();
+                                if (lastChar != '\n' && lastChar != '\r')
+                                {
+                                    var byteData = writeEncoding.GetBytes($"\r\n");
+                                    fs.Write(byteData, 0, byteData.Length);
+                                }
+                            }
+                            fs.Close();
+                        }
+                    }
+
+                    this.streamWriter = new StreamWriter(filepath, !isOverwrite, writeEncoding);
+                }
+                catch (Exception)
+                {
+                    StatusLog.Write($"{filepath} を書き込み用に開けませんでした。\n");
+                    return false;
+                }
             }
             return true;
         }

--- a/nicorankLib/api/NicoApi.cs
+++ b/nicorankLib/api/NicoApi.cs
@@ -1,4 +1,5 @@
-﻿using nicorankLib.Analyze.model;
+﻿using Microsoft.VisualBasic;
+using nicorankLib.Analyze.model;
 using nicorankLib.api.model;
 using nicorankLib.Common;
 using nicorankLib.Util;
@@ -111,25 +112,23 @@ namespace nicorankLib.api
                             int GetCounter = 0;
                             Parallel.ForEach(updateList, new ParallelOptions() { MaxDegreeOfParallelism = threadMax }, (wRank) =>
                             {
-                                    //if (idConvertMap.ContainsKey(wRank.ID))
-                                    //{
-                                    //var thmbInfo = GetTumbInfo(wRank, idConvertMap[wRank.ID]);
-                                    var thmbInfo = GetTumbInfo(wRank, wRank.ID);
-                                if (thmbInfo != null)
+                                var thmbInfo = GetTumbInfo(wRank, wRank.ID);
+          
+                                lock (lockObject)
                                 {
-                                    lock (lockObject)
+                                    StatusLog.Write(".");
+                                    if (GetCounter % 10 == 0 && GetCounter != 0)
                                     {
-                                        StatusLog.Write(".");
-                                        if (GetCounter % 10 == 0 && GetCounter != 0)
-                                        {
-                                            StatusLog.Write(GetCounter.ToString());
-                                        }
-                                        GetCounter++;
+                                        StatusLog.Write(GetCounter.ToString());
+                                    }
+                                    GetCounter++;
+                                    if (thmbInfo != null)
+                                    {
                                         thumbinfoList.Add(thmbInfo);
                                     }
                                 }
-                                    //}
-                                });
+                                
+                             });
 
                             // DBに登録する
                             // 一度古いデータを削除する
@@ -184,6 +183,7 @@ namespace nicorankLib.api
         /// <returns></returns>
         protected ThumbinfoBase GetTumbInfo(Ranking ranking, string id, string strXml = "")
         {
+            
             try
             {
                 if (string.IsNullOrEmpty(strXml))
@@ -201,7 +201,7 @@ namespace nicorankLib.api
             }
             catch (Exception ex)
             {
-                ErrLog.GetInstance().Write(ex);
+                ErrLog.GetInstance().Write($@"{APIURL}{id}  の情報を取得できませんでした");
                 return null;
             }
         }

--- a/nicorankLib/nicorankLib.csproj
+++ b/nicorankLib/nicorankLib.csproj
@@ -82,6 +82,7 @@
     <Reference Include="System.Text.Encoding.CodePages, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encoding.CodePages.4.5.1\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
* LogOfficial.dbにRankingDateテーブルを追加 →集計日がメンテナンス日かどうかを管理する

* 過去ランキング集計時にRankingDateテーブルが存在しない場合は自動で作成する仕様を追加

* 過去ランキング集計時にデータをを取得できなかった日について、メンテナンス日として登録するか確認する機能を追加

* 週間集計時に集計日がメンテナンス日だった場合、代わりに中間集計（デイリーランキングの合算）で計算するように修正 →Consoleに代替として中間集計を行うログが表示されます

* 中間集計時に該当期間にメンテナンス日が存在する場合は、対象日を計算対象外になるように変更 →デイリーランキングの計算する場合、「前日」→「メンテナンス日ではない直前の日」から差分を集計するように修正

その他
* エラーログ出力時にマルチスレッドへの対応が不十分だった潜在的な不具合を修正